### PR TITLE
Update org.gtk.Gtk3theme.Pop-light.json

### DIFF
--- a/org.gtk.Gtk3theme.Pop-light.json
+++ b/org.gtk.Gtk3theme.Pop-light.json
@@ -22,9 +22,9 @@
       "sources": [
         {
             "type": "file",
-            "url": "https://github.com/system76/pop-gtk-theme/releases/download/2.0.6-4/pop-gtk-theme_2.0.6.4_all.deb",
+            "url": "https://launchpad.net/~system76/+archive/ubuntu/pop/+files/pop-gtk-theme_3.0.2+1514583282+17.10~0a13823_all.deb",
             "dest-filename": "pop-gtk-theme.deb",
-            "sha256": "8ab13fe56305d87fe1f6b4c4388e978e66f7c7d2c39fb92031697afd97a8463f"
+            "sha256": "32d24e2ad6c8495f431c1351b568bbb7d778b4b0c0bc73fdf3fd36d911c05d94"
         }
       ]
     },


### PR DESCRIPTION
Update for latest version of the theme built from launchpad.